### PR TITLE
fix: login attempts keeps counting even after account is blocked

### DIFF
--- a/brints-estate-api/src/auth/providers/login-user.provider.ts
+++ b/brints-estate-api/src/auth/providers/login-user.provider.ts
@@ -55,6 +55,7 @@ export class LoginUserProvider {
       loginAttempts.blockedUntil > new Date()
     ) {
       await this.loginAttemptsProvider.attemptedLoginWhileBlocked(user);
+      return;
     }
 
     if (

--- a/brints-estate-api/src/login-attempts/providers/login-attempts.provider.ts
+++ b/brints-estate-api/src/login-attempts/providers/login-attempts.provider.ts
@@ -28,6 +28,7 @@ export class LoginAttemptsProvider {
   ): Promise<void> {
     loginAttempts.isBlocked = false;
     loginAttempts.blockedUntil = null;
+    loginAttempts.login_attempts = 0;
     await this.loginAttemptsRepository.save(loginAttempts);
     await this.userRepository.save(user);
   }
@@ -120,5 +121,6 @@ export class LoginAttemptsProvider {
     loginAttempts.isBlocked = false;
 
     await this.loginAttemptsRepository.save(loginAttempts);
+    await this.userRepository.save(user);
   }
 }


### PR DESCRIPTION
This pull request to `brints-estate-api` includes changes to improve the handling of user login attempts and blocking logic. The most important changes include adding a return statement to prevent further processing when a user is blocked and resetting the login attempt count upon successful login.

Improvements to login attempt handling:

* [`brints-estate-api/src/auth/providers/login-user.provider.ts`](diffhunk://#diff-66a3fc6ebfbe74c669044d9b45cd2fe51920787af0a386d5f710a70f2719427bR58): Added a return statement to exit the function early if the user is currently blocked to prevent any further processing.

Enhancements to blocking logic:

* [`brints-estate-api/src/login-attempts/providers/login-attempts.provider.ts`](diffhunk://#diff-b518fdaff5e6725f94d992a329e30fd60af3e3df576597d28f2048d78e98e0cfR31): Reset the `login_attempts` count to 0 when the user's block status is reset.

Code consistency:

* [`brints-estate-api/src/login-attempts/providers/login-attempts.provider.ts`](diffhunk://#diff-b518fdaff5e6725f94d992a329e30fd60af3e3df576597d28f2048d78e98e0cfR124): Added a missing save operation for the user repository to ensure the user's state is consistently updated.