### PR TITLE
docs: Documentation for authentication endpoints.

### DIFF
--- a/brints-estate-api/src/auth/auth.controller.ts
+++ b/brints-estate-api/src/auth/auth.controller.ts
@@ -36,11 +36,11 @@ import { HttpExceptionFilter } from '../exceptions/http-exception.filter';
 import {
   BadRequestResponse,
   ConflictResponse,
-  CreatedUserResponse,
-  LoginUserResponse,
   UnauthorizedResponse,
   InternalServerErrorResponse,
-} from './swagger_docs/responses.doc';
+} from './swagger_docs/common-responses.doc';
+import { CreatedUserResponse } from './swagger_docs/register-response.doc';
+import { LoggedInUserResponse } from './swagger_docs/login-response.doc';
 
 @Controller('auth')
 @ApiTags('Authentication')
@@ -87,7 +87,7 @@ export class AuthController {
   @ApiOperation({
     summary: 'Logs in a registered user and generates an access token',
   })
-  @ApiResponse(LoginUserResponse)
+  @ApiResponse(LoggedInUserResponse)
   @ApiUnauthorizedResponse(UnauthorizedResponse)
   @ApiBadRequestResponse(BadRequestResponse)
   @ApiInternalServerErrorResponse(InternalServerErrorResponse)

--- a/brints-estate-api/src/auth/dto/create-user.dto.ts
+++ b/brints-estate-api/src/auth/dto/create-user.dto.ts
@@ -15,6 +15,15 @@ import { UserGender } from '../../enums/gender.enum';
 
 export class CreateUserDto {
   @ApiProperty({
+    description: 'Upload an image avatar.',
+    type: String,
+    format: 'binary',
+    required: false,
+  })
+  @IsOptional()
+  image_url: string;
+
+  @ApiProperty({
     description: 'First name of the user',
     example: 'John',
     type: String,
@@ -26,21 +35,37 @@ export class CreateUserDto {
   @MaxLength(255)
   first_name: string;
 
-  @ApiProperty()
+  @ApiProperty({
+    description: 'Last name of the user',
+    example: 'Doe',
+    type: String,
+    required: true,
+  })
   @IsNotEmpty()
   @IsString()
   @MinLength(3)
   @MaxLength(255)
   last_name: string;
 
-  @ApiProperty()
+  @ApiProperty({
+    description: 'Enter your full email address',
+    example: 'example@test.com',
+    type: String,
+    required: true,
+  })
   @IsNotEmpty()
   @IsEmail()
   @MaxLength(255)
   @Transform(({ value }) => value.toLowerCase())
   email: string;
 
-  @ApiProperty()
+  @ApiProperty({
+    description:
+      'Password that includes uppercase, lowercase, number and symbol.',
+    example: 'Test123$',
+    type: String,
+    required: true,
+  })
   @IsNotEmpty()
   @IsString()
   @MinLength(8)
@@ -49,7 +74,12 @@ export class CreateUserDto {
   })
   password: string;
 
-  @ApiProperty()
+  @ApiProperty({
+    description: 'Repeat password.',
+    example: 'Test123$',
+    type: String,
+    required: true,
+  })
   @IsNotEmpty()
   @IsString()
   @MinLength(8)
@@ -58,7 +88,12 @@ export class CreateUserDto {
   })
   confirm_password: string;
 
-  @ApiProperty()
+  @ApiProperty({
+    description: 'Enter your country code.',
+    example: '234',
+    type: String,
+    required: true,
+  })
   @IsNotEmpty()
   @IsString()
   @Matches(/^[0-9]{1,5}$/, {
@@ -66,7 +101,12 @@ export class CreateUserDto {
   })
   country_code: string;
 
-  @ApiProperty()
+  @ApiProperty({
+    description: 'Enter your phone number.',
+    example: '080123456789',
+    type: String,
+    required: true,
+  })
   @IsNotEmpty()
   @IsString()
   @MaxLength(50)
@@ -84,19 +124,34 @@ export class CreateUserDto {
   @Transform(({ value }) => value.toLowerCase())
   gender: UserGender;
 
-  @ApiProperty()
+  @ApiProperty({
+    description: 'Accept terms and conditions to proceed.',
+    example: 'true',
+    type: Boolean,
+    required: true,
+  })
   @IsNotEmpty()
   @IsBoolean()
   @Transform(({ value }) => value === 'true')
   terms_and_conditions: boolean;
 
-  @ApiProperty()
+  @ApiProperty({
+    description: 'Accept our privacy policy to proceed.',
+    example: 'true',
+    type: Boolean,
+    required: true,
+  })
   @IsNotEmpty()
   @IsBoolean()
   @Transform(({ value }) => value === 'true')
   privacy_policy: boolean;
 
-  @ApiProperty()
+  @ApiProperty({
+    description: 'Accept our marketing.',
+    example: 'true',
+    type: Boolean,
+    required: false,
+  })
   @IsOptional()
   @IsBoolean()
   @Transform(({ value }) => value === 'true')

--- a/brints-estate-api/src/auth/dto/login.dto.ts
+++ b/brints-estate-api/src/auth/dto/login.dto.ts
@@ -2,13 +2,23 @@ import { ApiProperty } from '@nestjs/swagger';
 import { IsEmail, IsNotEmpty, IsString } from 'class-validator';
 
 export class LoginUserDto {
-  @ApiProperty()
+  @ApiProperty({
+    description: 'Enter your registered email address.',
+    example: 'example@test.com',
+    type: String,
+    required: true,
+  })
   @IsNotEmpty()
   @IsEmail()
   @IsString()
   email: string;
 
-  @ApiProperty()
+  @ApiProperty({
+    description: 'Enter your password.',
+    example: 'Test123$',
+    type: String,
+    required: true,
+  })
   @IsNotEmpty()
   @IsString()
   password: string;

--- a/brints-estate-api/src/auth/http/auth.register.endpoint.http
+++ b/brints-estate-api/src/auth/http/auth.register.endpoint.http
@@ -17,7 +17,7 @@ afia
 --WebKitFormBoundary
 Content-Disposition: form-data; name="email"
 
-aniebietafia87@gmail.com
+aniebietafia@gmail.com
 --WebKitFormBoundary
 Content-Disposition: form-data; name="password"
 
@@ -29,7 +29,7 @@ Test1234$
 --WebKitFormBoundary
 Content-Disposition: form-data; name="phone_number"
 
-08067581927
+08098194719
 --WebKitFormBoundary
 Content-Disposition: form-data; name="gender"
 
@@ -49,5 +49,23 @@ true
 --WebKitFormBoundary
 Content-Disposition: form-data; name="marketing"
 
-true
+false
 --WebKitFormBoundary--
+
+
+POST http://localhost:3001/api/auth/register
+Content-Type: application/json
+
+{
+    "first_name": "david",
+    "last_name": "lacroix",
+    "email": "aniebietafia@gmail.com",
+    "password": "Test1234$",
+    "confirm_password": "Test1234$",
+    "gender": "male",
+    "phone_number": "08098194719",
+    "country_code": "234",
+    "privacy_policy": "true",
+    "terms_and_conditions": "true",
+    "marketing_consent": "false"
+}

--- a/brints-estate-api/src/auth/swagger_docs/common-responses.doc.ts
+++ b/brints-estate-api/src/auth/swagger_docs/common-responses.doc.ts
@@ -1,0 +1,89 @@
+import { HttpStatus } from '@nestjs/common';
+
+export const ConflictResponse = {
+  description: 'Conflict',
+  status: HttpStatus.CONFLICT,
+  schema: {
+    type: 'object',
+    properties: {
+      success: {
+        type: 'boolean',
+        example: false,
+      },
+      status_code: {
+        type: 'number',
+        example: 409,
+      },
+      message: {
+        type: 'string',
+        example: 'User with email already exists',
+      },
+    },
+  },
+};
+
+export const BadRequestResponse = {
+  description: 'Bad request',
+  status: HttpStatus.BAD_REQUEST,
+  schema: {
+    type: 'object',
+    properties: {
+      success: {
+        type: 'boolean',
+        example: false,
+      },
+      status_code: {
+        type: 'number',
+        example: 400,
+      },
+      message: {
+        type: 'string',
+        example: 'Bad request',
+      },
+    },
+  },
+};
+
+export const UnauthorizedResponse = {
+  description: 'Unauthorized',
+  status: HttpStatus.UNAUTHORIZED,
+  schema: {
+    type: 'object',
+    properties: {
+      success: {
+        type: 'boolean',
+        example: false,
+      },
+      status_code: {
+        type: 'number',
+        example: 401,
+      },
+      message: {
+        type: 'string',
+        example: 'Unauthorized',
+      },
+    },
+  },
+};
+
+export const InternalServerErrorResponse = {
+  description: 'Internal server error',
+  status: HttpStatus.INTERNAL_SERVER_ERROR,
+  schema: {
+    type: 'object',
+    properties: {
+      success: {
+        type: 'boolean',
+        example: false,
+      },
+      status_code: {
+        type: 'number',
+        example: 500,
+      },
+      message: {
+        type: 'string',
+        example: 'Internal server error',
+      },
+    },
+  },
+};

--- a/brints-estate-api/src/auth/swagger_docs/login-response.doc.ts
+++ b/brints-estate-api/src/auth/swagger_docs/login-response.doc.ts
@@ -1,31 +1,6 @@
 import { HttpStatus } from '@nestjs/common';
-import { User } from 'src/users/entities/user.entity';
 
-export const CreatedUserResponse = {
-  description: 'User registration successful',
-  status: HttpStatus.CREATED,
-  type: User,
-};
-
-export const ConflictResponse = {
-  description: 'Conflict',
-  status: HttpStatus.CONFLICT,
-  schema: {
-    type: 'object',
-    properties: {
-      status_code: {
-        type: 'number',
-        example: 409,
-      },
-      message: {
-        type: 'string',
-        example: 'User with email already exists',
-      },
-    },
-  },
-};
-
-export const LoginUserResponse = {
+export const LoggedInUserResponse = {
   description: 'Login successful',
   status: HttpStatus.OK,
   schema: {
@@ -62,7 +37,7 @@ export const LoginUserResponse = {
                 example: '2024-11-01T13:51:21.374Z',
               },
               image_url: {
-                type: 'string',
+                type: ['string', null],
                 example: 'https://example.com/image.jpg',
               },
               first_name: {
@@ -135,64 +110,6 @@ export const LoginUserResponse = {
             },
           },
         },
-      },
-    },
-  },
-};
-
-export const BadRequestResponse = {
-  description: 'Bad request',
-  status: HttpStatus.BAD_REQUEST,
-  schema: {
-    type: 'object',
-    properties: {
-      success: {
-        type: 'boolean',
-        example: false,
-      },
-      status_code: {
-        type: 'number',
-        example: 400,
-      },
-      message: {
-        type: 'string',
-        example: 'Bad request',
-      },
-    },
-  },
-};
-
-export const UnauthorizedResponse = {
-  description: 'Unauthorized',
-  status: HttpStatus.UNAUTHORIZED,
-  schema: {
-    type: 'object',
-    properties: {
-      status_code: {
-        type: 'number',
-        example: 401,
-      },
-      message: {
-        type: 'string',
-        example: 'Unauthorized',
-      },
-    },
-  },
-};
-
-export const InternalServerErrorResponse = {
-  description: 'Internal server error',
-  status: HttpStatus.INTERNAL_SERVER_ERROR,
-  schema: {
-    type: 'object',
-    properties: {
-      status_code: {
-        type: 'number',
-        example: 500,
-      },
-      message: {
-        type: 'string',
-        example: 'Internal server error',
       },
     },
   },

--- a/brints-estate-api/src/auth/swagger_docs/register-response.doc.ts
+++ b/brints-estate-api/src/auth/swagger_docs/register-response.doc.ts
@@ -1,0 +1,42 @@
+import { HttpStatus } from '@nestjs/common';
+
+export const CreatedUserResponse = {
+  description: 'User registration successful',
+  status: HttpStatus.CREATED,
+  schema: {
+    type: 'object',
+    properties: {
+      api_version: { type: 'string', example: '1.0.0' },
+      message: { type: 'string', example: 'User registration successful' },
+      status_code: { type: 'number', example: 201 },
+      data: {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'string',
+            example: 'de45dbab-f570-48e7-9875-7c51f260c02d',
+          },
+          createdAt: { type: 'string', example: '2024-11-02T13:56:11.121Z' },
+          updatedAt: { type: 'string', example: '2024-11-02T13:56:11.121Z' },
+          image_url: {
+            type: ['string', null],
+            example: 'https://example.com/image.jpg',
+          },
+          first_name: { type: 'string', example: 'David' },
+          last_name: { type: 'string', example: 'Lacroix' },
+          email: { type: 'string', example: 'aniebietafia@gmail.com' },
+          phone_number: { type: 'string', example: '08098194719' },
+          gender: { type: 'string', example: 'male' },
+          isVerified: { type: 'boolean', example: false },
+          last_login: { type: ['string', null], example: null },
+          account_status: { type: 'string', example: 'inactive' },
+          role: { type: 'string', example: 'user' },
+          isTwoFAEnabled: { type: 'boolean', example: false },
+          terms_and_conditions: { type: 'boolean', example: true },
+          privacy_policy: { type: 'boolean', example: true },
+          marketing_consent: { type: 'boolean', example: false },
+        },
+      },
+    },
+  },
+};


### PR DESCRIPTION
This pull request includes several updates to the `brints-estate-api` project, focusing on improving the API documentation and restructuring response schemas. The changes include updates to the `CreateUserDto` and `LoginUserDto` classes, as well as modifications to the response documentation for various endpoints.

### Updates to API Documentation and Response Schemas:

* `brints-estate-api/src/auth/auth.controller.ts`:
  - Updated import paths for response schemas and renamed `LoginUserResponse` to `LoggedInUserResponse`. [[1]](diffhunk://#diff-eda9aa75d14002002b169ff707931dd54cef573f4254444e8662df2b102ef66dL39-R43) [[2]](diffhunk://#diff-eda9aa75d14002002b169ff707931dd54cef573f4254444e8662df2b102ef66dL90-R90)

* `brints-estate-api/src/auth/dto/create-user.dto.ts`:
  - Enhanced `CreateUserDto` with detailed `ApiProperty` descriptions for each field, including optional `image_url` field. [[1]](diffhunk://#diff-399e843456cc14f03643362c218ff08c83d2078b4f5ebc0bef64511a887b310cR17-R25) [[2]](diffhunk://#diff-399e843456cc14f03643362c218ff08c83d2078b4f5ebc0bef64511a887b310cL29-R68) [[3]](diffhunk://#diff-399e843456cc14f03643362c218ff08c83d2078b4f5ebc0bef64511a887b310cL52-R82) [[4]](diffhunk://#diff-399e843456cc14f03643362c218ff08c83d2078b4f5ebc0bef64511a887b310cL61-R109) [[5]](diffhunk://#diff-399e843456cc14f03643362c218ff08c83d2078b4f5ebc0bef64511a887b310cL87-R154)

* `brints-estate-api/src/auth/dto/login.dto.ts`:
  - Added detailed `ApiProperty` descriptions for `email` and `password` fields in `LoginUserDto`.

### Restructuring Response Schemas:

* `brints-estate-api/src/auth/swagger_docs/common-responses.doc.ts`:
  - Added common response schemas for `ConflictResponse`, `BadRequestResponse`, `UnauthorizedResponse`, and `InternalServerErrorResponse`.

* `brints-estate-api/src/auth/swagger_docs/login-response.doc.ts`:
  - Renamed and updated `LoginUserResponse` to `LoggedInUserResponse` and moved common responses to `common-responses.doc.ts`. [[1]](diffhunk://#diff-33e749cf628bcb58e6173ce3e45f4f992882b86b7f5aaad336f113caed0deac2L2-R3) [[2]](diffhunk://#diff-33e749cf628bcb58e6173ce3e45f4f992882b86b7f5aaad336f113caed0deac2L65-R40) [[3]](diffhunk://#diff-33e749cf628bcb58e6173ce3e45f4f992882b86b7f5aaad336f113caed0deac2L142-L199)

* `brints-estate-api/src/auth/swagger_docs/register-response.doc.ts`:
  - Created a new response schema for `CreatedUserResponse` detailing the structure of the user registration response.

### Minor Changes:

* `brints-estate-api/src/auth/http/auth.register.endpoint.http`:
  - Updated test data for the registration endpoint, including email, phone number, and marketing consent values. [[1]](diffhunk://#diff-7a05c8ae3d053443f0a85a033f24dd5810a6c2fc1d69c4272fb810bcd805575cL20-R20) [[2]](diffhunk://#diff-7a05c8ae3d053443f0a85a033f24dd5810a6c2fc1d69c4272fb810bcd805575cL32-R32) [[3]](diffhunk://#diff-7a05c8ae3d053443f0a85a033f24dd5810a6c2fc1d69c4272fb810bcd805575cL52-R71)